### PR TITLE
FIX: windows-specific path-delimiter in create_code_archive_for_blackboard_WINDOWS.bat

### DIFF
--- a/create_code_archive_for_blackboard_WINDOWS.bat
+++ b/create_code_archive_for_blackboard_WINDOWS.bat
@@ -1,2 +1,2 @@
-gloom/vendor/7z/7za.exe a source.zip gloom/src gloom/shaders
+gloom\vendor\7z\7za.exe a source.zip gloom\src gloom\shaders
 pause


### PR DESCRIPTION
Execution of the bat file would not work in Command Prompt otherwise.